### PR TITLE
bugfix in test_plot_funs

### DIFF
--- a/6_visualize/src/test_plot_funs.R
+++ b/6_visualize/src/test_plot_funs.R
@@ -9,7 +9,7 @@ test_plot_funs <- function(..., png_file=NA, task_file='6_timestep_gif_tasks.yml
   # call create_animation_frame. we'll always want the view_fun as a base layer
   args <- c(
     list(png_file=png_file,
-         config=scmake('view_cfg', verbose=FALSE),
+         config=scmake('timestep_frame_config', verbose=FALSE),
          view_fun=scmake('view_fun', verbose=FALSE)),
     plot_funs)
   do.call(create_animation_frame, args)


### PR DESCRIPTION
Oneliner - realized I was using the wrong config list in test_plot_funs, but it only matters if you specify a png_file other than NA. Which raises another point worth sharing: you can build a test plot and save it to png if you want, it's just not the default. That way you can get the aspect ratio and fonts right while still staying a little simpler than a complete timestamp frame

Example:
```r
test_plot_funs(watermark_fun, datetime_fun_20180914_00, png_file='test.png')
```
![test](https://user-images.githubusercontent.com/12039957/48094820-2f2a6980-e1e1-11e8-9351-03281a50ee16.png)
