### PR TITLE
flip legend colors when building legend from the right side

### DIFF
--- a/6_visualize/src/prep_legend_fun.R
+++ b/6_visualize/src/prep_legend_fun.R
@@ -35,6 +35,7 @@ prep_legend_fun <- function(percentiles_str, sites_color_palette,
     } else if (x_pos == 'right'){
       x_edge <- coord_space[2] - strwidth(right_text)
       shift_xdir <- -1
+      legend_cols <- rev(legend_cols)
     }
 
     if (y_pos == 'bottom'){


### PR DESCRIPTION
Building from the right instead of the left made the colors reverse:

![image](https://user-images.githubusercontent.com/13220910/48166560-8b0ef400-e2ae-11e8-80a6-8c04a6acaa89.png)

This code flips it to be correct when the legend is built from the right edge of the map:
![image](https://user-images.githubusercontent.com/13220910/48166584-9e21c400-e2ae-11e8-9c89-f9773a99aedc.png)
