### PR TITLE
Rough draft of callouts implementation

### DIFF
--- a/6_visualize.yml
+++ b/6_visualize.yml
@@ -21,6 +21,7 @@ sources:
   - 6_visualize/src/prep_legend_fun.R
   - 6_visualize/src/prep_watermark_fun.R
   - 6_visualize/src/prep_gage_sites_fun.R
+  - 6_visualize/src/prep_callouts_fun.R
   - 6_visualize/src/combine_animation_frames.R
 
 targets:
@@ -104,6 +105,8 @@ targets:
     command: viz_config[I(c('width','height'))]
   timestep_frame_step:
     command: viz_config[[I('frame_step')]]
+  callouts_cfg:
+    command: viz_config[[I('callouts')]]
 
   timestep_gif_tasks:
     command: create_timestep_gif_tasks(

--- a/6_visualize/src/create_gif_tasks.R
+++ b/6_visualize/src/create_gif_tasks.R
@@ -24,7 +24,7 @@ create_timestep_gif_tasks <- function(timestep_ind, folders){
   gage_sites <- scipiper::create_task_step(
     step_name = 'gage_sites',
     target_name = function(task_name, step_name, ...){
-      sprintf('gage_sites_plot_fun_%s', task_name)
+      sprintf('gage_sites_fun_%s', task_name)
     },
     command = function(task_name, ...){
       cur_task <- dplyr::filter(rename(tasks, tn=task_name), tn==task_name)
@@ -37,7 +37,7 @@ create_timestep_gif_tasks <- function(timestep_ind, folders){
   callouts <- scipiper::create_task_step(
     step_name = 'callouts',
     target_name = function(task_name, step_name, ...){
-      sprintf('callouts_plot_fun_%s', task_name)
+      sprintf('callouts_fun_%s', task_name)
     },
     command = function(task_name, ...){
       cur_task <- dplyr::filter(rename(tasks, tn=task_name), tn==task_name)
@@ -62,8 +62,8 @@ create_timestep_gif_tasks <- function(timestep_ind, folders){
         "basemap_fun,",
         "legend_fun,",
         "watermark_fun,",
-        "gage_sites_plot_fun_%s,"=cur_task$tn,
-        "callouts_plot_fun_%s,"=cur_task$tn,
+        "gage_sites_fun_%s,"=cur_task$tn,
+        "callouts_fun_%s,"=cur_task$tn,
         "datetime_fun_%s)"=cur_task$tn
       )
     }

--- a/6_visualize/src/create_gif_tasks.R
+++ b/6_visualize/src/create_gif_tasks.R
@@ -34,6 +34,17 @@ create_timestep_gif_tasks <- function(timestep_ind, folders){
     depends = "2_process/out/dv_stat_colors.rds"
   )
 
+  callouts <- scipiper::create_task_step(
+    step_name = 'callouts',
+    target_name = function(task_name, step_name, ...){
+      sprintf('callouts_plot_fun_%s', task_name)
+    },
+    command = function(task_name, ...){
+      cur_task <- dplyr::filter(rename(tasks, tn=task_name), tn==task_name)
+      sprintf("prep_callouts_fun(callouts_cfg = callouts_cfg, dateTime=I('%s'))", format(cur_task$timestep, "%Y-%m-%d %H:%M:%S"))
+    }
+  )
+
   # ---- main target for each task: the
 
   complete_png <- scipiper::create_task_step(
@@ -52,6 +63,7 @@ create_timestep_gif_tasks <- function(timestep_ind, folders){
         "legend_fun,",
         "watermark_fun,",
         "gage_sites_plot_fun_%s,"=cur_task$tn,
+        "callouts_plot_fun_%s,"=cur_task$tn,
         "datetime_fun_%s)"=cur_task$tn
       )
     }
@@ -64,6 +76,7 @@ create_timestep_gif_tasks <- function(timestep_ind, folders){
     task_steps=list(
       datetime_frame,
       gage_sites,
+      callouts,
       complete_png),
     add_complete=FALSE,
     final_steps='complete_png',

--- a/6_visualize/src/prep_callouts_fun.R
+++ b/6_visualize/src/prep_callouts_fun.R
@@ -1,18 +1,44 @@
 
-prep_callout_fun <- function(callout_text_cfg){
+prep_callouts_fun <- function(callouts_cfg, dateTime){
+
+  this_date <- as.POSIXct(dateTime, tz = "UTC") #watch timezones if we ever switch from daily data
+  this_date_callouts <- lapply(callouts_cfg, function(x, this_date) {
+    start <- as.POSIXct(x$dates$start, tz = "UTC")
+    end <- as.POSIXct(x$dates$end, tz = "UTC")
+    if(this_date >= start & this_date <= end) {
+      callouts_to_plot <- x
+    } else {
+      callouts_to_plot <- NULL
+    }
+    return(callouts_to_plot)
+  }, this_date)
+
+  # keep only non-NULL elements
+  this_date_callouts <- this_date_callouts[!unlist(lapply(this_date_callouts, is.null))]
 
   plot_fun <- function(){
 
-    # it is up to the user to parse the text to make sure it doesn't end up outside of the margins@
+    # it is up to the user to parse the text to make sure it doesn't end up outside of the margins
     coord_space <- par()$usr
-    x <- callout_text_cfg$x_loc * diff(coord_space[1:2])
-    y <- callout_text_cfg$y_loc * diff(coord_space[3:4])
-    callouts <- callout_text_cfg$label
 
-    for (i in 1:length(callouts)) {
-      y_i <- y + (i-1)*strheight(callouts)
-      text(x, y_i, labels = callouts, cex = 1.6, pos = callout_text_cfg$pos, col = 'grey40')
+    n_callouts <- length(this_date_callouts)
+    if(n_callouts > 0) {
+      for(n in 1:n_callouts) {
+        callout_text_cfg_n <- this_date_callouts[[n]]$text
+        x <- coord_space[1] + callout_text_cfg_n$x_loc * diff(coord_space[1:2])
+        y <- coord_space[3] + callout_text_cfg_n$y_loc * diff(coord_space[3:4])
+        callouts <- callout_text_cfg_n$label
+
+        for (i in 1:length(callouts)) {
+          y_i <- y - (i-1)*strheight(callouts[i])*2
+          text(x, y_i, labels = callouts[i],
+               cex = callout_text_cfg_n$cex,
+               pos = callout_text_cfg_n$pos,
+               col = 'grey40')
+        }
+      }
     }
+
   }
   return(plot_fun)
 }

--- a/6_visualize/src/prep_callouts_fun.R
+++ b/6_visualize/src/prep_callouts_fun.R
@@ -6,39 +6,43 @@ prep_callouts_fun <- function(callouts_cfg, dateTime){
     start <- as.POSIXct(x$dates$start, tz = "UTC")
     end <- as.POSIXct(x$dates$end, tz = "UTC")
     if(this_date >= start & this_date <= end) {
-      callouts_to_plot <- x
+      return(x)
     } else {
-      callouts_to_plot <- NULL
+      return(NULL)
     }
-    return(callouts_to_plot)
   }, this_date)
 
   # keep only non-NULL elements
   this_date_callouts <- this_date_callouts[!unlist(lapply(this_date_callouts, is.null))]
 
-  plot_fun <- function(){
+  rm(callouts_cfg, dateTime, this_date)
 
-    # it is up to the user to parse the text to make sure it doesn't end up outside of the margins
-    coord_space <- par()$usr
+  n_callouts <- length(this_date_callouts)
+  if(n_callouts > 0) {
+    plot_fun <- function(){
 
-    n_callouts <- length(this_date_callouts)
-    if(n_callouts > 0) {
-      for(n in 1:n_callouts) {
-        callout_text_cfg_n <- this_date_callouts[[n]]$text
-        x <- coord_space[1] + callout_text_cfg_n$x_loc * diff(coord_space[1:2])
-        y <- coord_space[3] + callout_text_cfg_n$y_loc * diff(coord_space[3:4])
-        callouts <- callout_text_cfg_n$label
+      # it is up to the user to parse the text to make sure it doesn't end up outside of the margins
+      coord_space <- par()$usr
 
-        for (i in 1:length(callouts)) {
-          y_i <- y - (i-1)*strheight(callouts[i])*2
-          text(x, y_i, labels = callouts[i],
-               cex = callout_text_cfg_n$cex,
-               pos = callout_text_cfg_n$pos,
-               col = 'grey40')
+        for(n in 1:n_callouts) {
+          callout_text_cfg_n <- this_date_callouts[[n]]$text
+          x <- coord_space[1] + callout_text_cfg_n$x_loc * diff(coord_space[1:2])
+          y <- coord_space[3] + callout_text_cfg_n$y_loc * diff(coord_space[3:4])
+          callouts <- callout_text_cfg_n$label
+
+          for (i in 1:length(callouts)) {
+            y_i <- y - (i-1)*strheight(callouts[i])*2
+            text(x, y_i, labels = callouts[i],
+                 cex = callout_text_cfg_n$cex,
+                 pos = callout_text_cfg_n$pos,
+                 col = 'grey40')
+          }
         }
       }
-    }
 
+  } else {
+    rm(this_date_callouts, n_callouts)
+    plot_fun <- function() { NULL }
   }
   return(plot_fun)
 }

--- a/6_visualize/src/prep_callouts_fun.R
+++ b/6_visualize/src/prep_callouts_fun.R
@@ -1,0 +1,18 @@
+
+prep_callout_fun <- function(callout_text_cfg){
+
+  plot_fun <- function(){
+
+    # it is up to the user to parse the text to make sure it doesn't end up outside of the margins@
+    coord_space <- par()$usr
+    x <- callout_text_cfg$x_loc * diff(coord_space[1:2])
+    y <- callout_text_cfg$y_loc * diff(coord_space[3:4])
+    callouts <- callout_text_cfg$label
+
+    for (i in 1:length(callouts)) {
+      y_i <- y + (i-1)*strheight(callouts)
+      text(x, y_i, labels = callouts, cex = 1.6, pos = callout_text_cfg$pos, col = 'grey40')
+    }
+  }
+  return(plot_fun)
+}

--- a/viz_config.yml
+++ b/viz_config.yml
@@ -61,9 +61,22 @@ component_placement:
 
 callouts:
   -
-    dates: ["2018-06-01", "2018-06-11"]
+    dates:
+      start: "2018-06-01"
+      end: "2018-06-11"
     text:
         label: ["Flooding in the northeast", "driven by x…"]
         x_loc: 0.88 #this is in percentage space, relative to the plotting device
         y_loc: 0.65
         pos: 3
+        cex: 1.2
+  -
+    dates:
+      start: "2018-09-15"
+      end: "2018-09-17"
+    text:
+        label: ["Something in the southwest", "and its explanation"]
+        x_loc: 0.25 #this is in percentage space, relative to the plotting device
+        y_loc: 0.50
+        pos: 4
+        cex: 2

--- a/viz_config.yml
+++ b/viz_config.yml
@@ -62,8 +62,8 @@ component_placement:
 callouts:
   -
     dates:
-      start: "2018-06-01"
-      end: "2018-06-11"
+      start: "2018-09-09"
+      end: "2018-09-16"
     text:
         label: ["Flooding in the northeast", "driven by x…"]
         x_loc: 0.88 #this is in percentage space, relative to the plotting device
@@ -73,7 +73,7 @@ callouts:
   -
     dates:
       start: "2018-09-15"
-      end: "2018-09-17"
+      end: "2018-09-19"
     text:
         label: ["Something in the southwest", "and its explanation"]
         x_loc: 0.25 #this is in percentage space, relative to the plotting device

--- a/viz_config.yml
+++ b/viz_config.yml
@@ -59,3 +59,11 @@ component_placement:
     ytop_stn: 0.85 # top y coordinate of the text and legend for the short-term network
     ytop_more: 0.4 # top y coordinate of the text and URL for where to learn more
 
+callouts:
+  -
+    dates: ["2018-06-01", "2018-06-11"]
+    text:
+        label: ["Flooding in the northeast", "driven by x…"]
+        x_loc: 0.88 #this is in percentage space, relative to the plotting device
+        y_loc: 0.65
+        pos: 3


### PR DESCRIPTION
I want to do a check about how I've decided to implement callouts before moving forward. 

I followed @jread-usgs example yaml in #31 with a few minor changes. Each callout needs a `dates` and `text` section. `dates` needs to have a start and end date for the window to which this callout applies. The `text` section needs `label` (which can be any length vector, each string being a separate line of the paragraph), x_loc, y_loc as percentages of the full figure (from bottom left), pos, and cex. We can work on adding text boxes for different colored backgrounds in a future PR as well as actually add our proposed events (see #18).

I set this up so that each timestep calls the `prep_callouts_fun`. Inside the function, it is determined whether or not a callout is applicable to that date and cycles through adding them to the plot. It handles callouts that overlap in their window.

Here is a quick example with our September week test (slowed down) with fake callouts:
![year_in_review](https://user-images.githubusercontent.com/13220910/48222923-6f155c00-e35b-11e8-8294-770e6919fef5.gif)

I don't know why the legend and timestamp text is so small....