### PR TITLE
Fix legend & datetime stamp to be big again

### DIFF
--- a/6_visualize/src/prep_datetime_fun.R
+++ b/6_visualize/src/prep_datetime_fun.R
@@ -1,6 +1,6 @@
 
 prep_datetime_fun <- function(datetime, component_placement, date_display_tz){
-  
+
   datetime <- strftime(as.POSIXct(datetime, tz="UTC"), format = '%b %d %I:%M %p %Z', tz = date_display_tz)
 
   plot_fun <- function(){
@@ -20,7 +20,7 @@ prep_datetime_fun <- function(datetime, component_placement, date_display_tz){
     x1 <- coord_space_left + coord_width * component_placement$x1
     y1 <- coord_space_bot + coord_height * component_placement$y1 # bump up from bottom of figure (trying to place above the USGS watermark)
 
-    text(x = x1, y = y1, labels = datetime, cex = 1.6, pos = 4, col = 'grey40')
+    text(x = x1, y = y1, labels = datetime, cex = component_placement$cex, pos = 4, col = 'grey40')
   }
   return(plot_fun)
 }

--- a/6_visualize/src/prep_legend_fun.R
+++ b/6_visualize/src/prep_legend_fun.R
@@ -21,8 +21,8 @@ prep_legend_fun <- function(percentiles_str, sites_color_palette,
 
     # percentage of X domain for circle diameter; assumes 175 is max cex
     # used for spacing circles along the x and y directions
-    point_perc <- legend_cfg$point_cex/175
-    point_dia_usr <- point_perc*diff(coord_space[1:2])
+    point_width <- legend_cfg$point_cex*strwidth("O")
+    point_height <- legend_cfg$point_cex*strheight("O")
 
     # Legend text
     left_text <- "Lower flows"
@@ -39,10 +39,10 @@ prep_legend_fun <- function(percentiles_str, sites_color_palette,
     }
 
     if (y_pos == 'bottom'){
-      y_edge <- coord_space[3] + point_dia_usr*0.75 + strheight("G")*1.5 # the 1.5 multiplier captures letters below the line (e.g. g,j,p)
+      y_edge <- coord_space[3] + point_height
       shift_ydir <- 1
     } else if (y_pos == 'top'){
-      y_edge <- coord_space[4] - point_dia_usr*0.75 - strheight("Gg")*1.5
+      y_edge <- coord_space[4] - point_height
       shift_ydir <- -1
     }
 
@@ -51,11 +51,11 @@ prep_legend_fun <- function(percentiles_str, sites_color_palette,
     } else if (legend_cfg$y_text_pos == 'over'){
       shift_ytext <- 1
     }
-    y_text <- y_edge + (point_dia_usr*shift_ytext) + (point_dia_usr*0.1*shift_ytext)
+    y_text <- y_edge + (point_height*0.5*shift_ytext)
 
-    x_start <- x_edge + point_dia_usr/2*shift_xdir
+    x_start <- x_edge + point_width*shift_xdir
     for(n in 1:length(legend_cols)) {
-      x_loc <- x_start + (n-1)*point_dia_usr*shift_xdir
+      x_loc <- x_start + (n-1)*point_width/2*shift_xdir
       points(x_loc, y_edge, bg = paste0(legend_cols[n], alpha_hex),
              col = legend_cols[n], pch = 21, cex = legend_cfg$point_cex, lwd = 1)
     }

--- a/viz_config.yml
+++ b/viz_config.yml
@@ -34,8 +34,8 @@ gage_style:
   pch: 16
   cex: 0.7
 legend_cfg:
-  point_cex: 4
-  text_cex: 0.9
+  point_cex: 7
+  text_cex: 2
   text_col: "#161616"
   y_text_pos: "under" # "under" or "over" accepted
 
@@ -49,9 +49,10 @@ animation:
 component_placement:
   watermark_x_pos: "left"
   watermark_y_pos: "top"
-  datetime: # above watermark for now
+  datetime: # below watermark for now
     x1: 0.005
     y1: 0.85
+    cex: 2.5
   legend_x_pos: "right"
   legend_y_pos: "bottom"
   outro: # outro text & legend roughly, but not exactly, fit where the sparklines were


### PR DESCRIPTION
They got tiny when we doubled the pixels to make the resolution better (#55). This makes them better :)

![image](https://user-images.githubusercontent.com/13220910/48382400-94c99a80-e6a6-11e8-9de0-36a95ec9da89.png)

(please ignore the windows terrible rendering of the spatial lines...at least I'm pretty sure that is what is happening)

