### PR TITLE
Add optional boxes behind callouts

### DIFF
--- a/2_process/out/dv_stat_colors.rds.ind
+++ b/2_process/out/dv_stat_colors.rds.ind
@@ -1,2 +1,2 @@
-hash: a8900b467a5b0fdfea415d6acbad0f69
+hash: 2cf754337a8fad8f7898b766b81b0ba7
 

--- a/6_visualize/src/prep_callouts_fun.R
+++ b/6_visualize/src/prep_callouts_fun.R
@@ -80,7 +80,7 @@ prep_callouts_fun <- function(callouts_cfg, dateTime){
                  xright = x + x_buffer_right,
                  ybottom = y_i - max_strheight - y_buffer_bottom,
                  ytop = y + y_buffer_top,
-                 col = "#bdbdbd50", border = NA)
+                 col = "#bdbdbd5E", border = NA)
           }
         }
       }

--- a/6_visualize/src/prep_callouts_fun.R
+++ b/6_visualize/src/prep_callouts_fun.R
@@ -25,17 +25,62 @@ prep_callouts_fun <- function(callouts_cfg, dateTime){
       coord_space <- par()$usr
 
         for(n in 1:n_callouts) {
+          addBox <- ifelse(!is.null(this_date_callouts[[n]]$addBox),
+                           this_date_callouts[[n]]$addBox, FALSE)
           callout_text_cfg_n <- this_date_callouts[[n]]$text
           x <- coord_space[1] + callout_text_cfg_n$x_loc * diff(coord_space[1:2])
           y <- coord_space[3] + callout_text_cfg_n$y_loc * diff(coord_space[3:4])
           callouts <- callout_text_cfg_n$label
 
+          font_x_multiplier <- 2.1 # for Abel
+          font_y_multiplier <- 3 # for Abel
+
           for (i in 1:length(callouts)) {
-            y_i <- y - (i-1)*strheight(callouts[i])*2
+            y_i <- y - (i-1)*strheight(callouts[i])*font_y_multiplier
             text(x, y_i, labels = callouts[i],
                  cex = callout_text_cfg_n$cex,
                  pos = callout_text_cfg_n$pos,
                  col = 'grey40')
+          }
+
+          if(addBox) {
+            max_strwidth <- max(strwidth(callouts))*font_x_multiplier # buffer for abel since it can't do that correctly
+            max_strheight <- max(strheight(callouts))*font_y_multiplier
+
+            x_buffer_left <- switch(
+              as.character(callout_text_cfg_n$pos),
+              "NULL" = max_strwidth/2, # centered
+              "2" = max_strwidth, # left of
+              "4" = 0, # right of
+              max_strwidth/2 # default is centered
+            )
+            x_buffer_right <- switch(
+              as.character(callout_text_cfg_n$pos),
+              "NULL" = max_strwidth/2, # centered
+              "2" = 0, # left of
+              "4" = max_strwidth, # right of
+              max_strwidth/2 # default is centered
+            )
+            y_buffer_top <- switch(
+              as.character(callout_text_cfg_n$pos),
+              "NULL" = 0,
+              "1" = 0, # below
+              "3" = max_strheight, # above
+              0 # default
+            )
+            y_buffer_bottom <- switch(
+              as.character(callout_text_cfg_n$pos),
+              "NULL" = 0,
+              "1" = 0, # below is the default position for text
+              "3" = -max_strheight, # above
+              0 # default
+            )
+
+            rect(xleft = x - x_buffer_left,
+                 xright = x + x_buffer_right,
+                 ybottom = y_i - max_strheight - y_buffer_bottom,
+                 ytop = y + y_buffer_top,
+                 col = "#bdbdbd50", border = NA)
           }
         }
       }

--- a/6_visualize/src/prep_callouts_fun.R
+++ b/6_visualize/src/prep_callouts_fun.R
@@ -25,8 +25,8 @@ prep_callouts_fun <- function(callouts_cfg, dateTime){
       coord_space <- par()$usr
 
         for(n in 1:n_callouts) {
-          addBox <- ifelse(!is.null(this_date_callouts[[n]]$addBox),
-                           this_date_callouts[[n]]$addBox, FALSE)
+          add_box <- ifelse(!is.null(this_date_callouts[[n]]$add_box),
+                            this_date_callouts[[n]]$add_box, FALSE)
           callout_text_cfg_n <- this_date_callouts[[n]]$text
           x <- coord_space[1] + callout_text_cfg_n$x_loc * diff(coord_space[1:2])
           y <- coord_space[3] + callout_text_cfg_n$y_loc * diff(coord_space[3:4])
@@ -43,7 +43,7 @@ prep_callouts_fun <- function(callouts_cfg, dateTime){
                  col = 'grey40')
           }
 
-          if(addBox) {
+          if(add_box) {
             max_strwidth <- max(strwidth(callouts))*font_x_multiplier # buffer for abel since it can't do that correctly
             max_strheight <- max(strheight(callouts))*font_y_multiplier
 

--- a/6_visualize/src/prep_datetime_fun.R
+++ b/6_visualize/src/prep_datetime_fun.R
@@ -3,6 +3,8 @@ prep_datetime_fun <- function(datetime, component_placement, date_display_tz){
 
   datetime <- strftime(as.POSIXct(datetime, tz="UTC"), format = '%b %d %I:%M %p %Z', tz = date_display_tz)
 
+  rm(date_display_tz)
+
   plot_fun <- function(){
     # coordinate space (edges, width, height)
     coord_space <- par()$usr

--- a/6_visualize/src/prep_gage_sites_fun.R
+++ b/6_visualize/src/prep_gage_sites_fun.R
@@ -3,6 +3,9 @@ prep_gage_sites_fun <- function(percentile_color_data_ind, sites_sp, dateTime){
   percentile_color_data <- readRDS(as_data_file(percentile_color_data_ind))
   this_date_colors <- filter(percentile_color_data, dateTime == this_date)
   sites_sp@data <- left_join(sites_sp@data, this_date_colors, by = "site_no")
+
+  rm(this_date, percentile_color_data, this_date_colors)
+
   gage_sites_plot_fun <- function(){
     #single plot of gages w/color
     plot(sites_sp, add = TRUE, pch = sites_sp$shape, col = sites_sp$color, cex = sites_sp$size)

--- a/6_visualize/src/prep_legend_fun.R
+++ b/6_visualize/src/prep_legend_fun.R
@@ -13,6 +13,8 @@ prep_legend_fun <- function(percentiles_str, sites_color_palette,
 
   alpha_hex <- 'CC'
 
+  rm(percentiles)
+
   plot_fun <- function(){
 
     # compute position info shared across multiple legend elements

--- a/6_visualize/src/prep_legend_fun.R
+++ b/6_visualize/src/prep_legend_fun.R
@@ -56,7 +56,7 @@ prep_legend_fun <- function(percentiles_str, sites_color_palette,
 
     x_start <- x_edge + point_width*shift_xdir
     for(n in 1:length(legend_cols)) {
-      x_loc <- x_start + (n-1)*point_width/2*shift_xdir
+      x_loc <- x_start + (n-1)*point_width*0.65*shift_xdir
       points(x_loc, y_edge, bg = paste0(legend_cols[n], alpha_hex),
              col = legend_cols[n], pch = 21, cex = legend_cfg$point_cex, lwd = 1)
     }

--- a/build/status/Ml9wcm9jZXNzL291dC9kdl9zdGF0X2NvbG9ycy5yZHMuaW5k.yml
+++ b/build/status/Ml9wcm9jZXNzL291dC9kdl9zdGF0X2NvbG9ycy5yZHMuaW5k.yml
@@ -1,13 +1,14 @@
 version: 0.3.0
 name: 2_process/out/dv_stat_colors.rds.ind
 type: file
-hash: a83eb4c7653e35d031c7b31d6a815491
-time: 2018-11-09 16:03:51 UTC
+hash: 232c9fec9628ab9995a48ade6c4aa9f0
+time: 2018-11-13 17:15:01 UTC
 depends:
   2_process/out/dv_stats.rds.ind: e3a2725a5a545caa0a1cce7b4555500c
-  sites_color_palette: ff2cbc2b3f91933a46f1062a4703a9ac
+  sites_color_palette: f4bda45333f2e464042d4b4851a2ec49
+  gage_style_config: e3491cdd3ecb0a0a35adcba91aa1096e
 fixed: 486c649635ebbc0a9b69d6a88fe562b4
 code:
   functions:
-    process_dv_stat_colors: 525e74d3cc1839c1a5134d07723cf261
+    process_dv_stat_colors: 83a8ca3fc35553deb61f65e39fb28081
 

--- a/viz_config.yml
+++ b/viz_config.yml
@@ -89,6 +89,7 @@ callouts:
         y_loc: 0.6
         pos: 3
         cex: 2
+    addBox: TRUE
   -
     dates:
       start: "2018-07-01"
@@ -99,6 +100,7 @@ callouts:
         y_loc: 0.50
         pos: 1
         cex: 2
+    addBox: TRUE
   -
     dates:
       start: "2018-09-14"

--- a/viz_config.yml
+++ b/viz_config.yml
@@ -47,7 +47,7 @@ legend_cfg:
 
 # gif options
 animation:
-  frame_rate: 1 #original input frames per second
+  frame_rate: 10 #original input frames per second
   output_frame_rate: 10 #fps, but the actual frames in the video (not 1:1 with input)
 
 # Image placement for function calls of USGS watermark, legend, datetime, etc..

--- a/viz_config.yml
+++ b/viz_config.yml
@@ -89,7 +89,7 @@ callouts:
         y_loc: 0.6
         pos: 3
         cex: 2
-    addBox: TRUE
+    add_box: TRUE
   -
     dates:
       start: "2018-07-01"
@@ -100,7 +100,7 @@ callouts:
         y_loc: 0.50
         pos: 1
         cex: 2
-    addBox: TRUE
+    add_box: TRUE
   -
     dates:
       start: "2018-09-14"


### PR DESCRIPTION
You need to add `addBox: TRUE` with the callout in `viz_config.yml` in order to get one to appear. Fixes #5.

![image](https://user-images.githubusercontent.com/13220910/48432357-bf186800-e739-11e8-8556-aaa4ea88ab3c.png)

I ran the following code to generate the image above to verify that all callouts look as expected:

```
test_plot_funs(view_fun, basemap_fun, watermark_fun, legend_fun, 
               datetime_fun_20180915_00, gage_sites_fun_20180915_00, callouts_fun_20180715_00, 
               callouts_fun_20180221_00, callouts_fun_20171210_00, callouts_fun_20180914_00, 
               callouts_fun_20180922_00, png_file = 'test.png')
```