### PR TITLE
Seasonality animation

### DIFF
--- a/2_process.yml
+++ b/2_process.yml
@@ -19,6 +19,7 @@ sources:
   - 2_process/src/process_site_stats.R
   - 2_process/src/process_dv_stats.R
   - 2_process/src/process_dv_stat_colors.R
+  - 2_process/src/process_seasonality_colors.R
   - 2_process/src/project_shift_points.R
   - 2_process/src/project_shift_states.R
 
@@ -30,6 +31,7 @@ targets:
       - 2_process/out/site_stats_clean.rds.ind
       - 2_process/out/dv_stats.rds.ind
       - 2_process/out/dv_stat_colors.rds.ind
+      - 2_process/out/dv_seasonality_colors.rds.ind
       - states_shifted
       - site_locations_shifted
 
@@ -72,6 +74,16 @@ targets:
       gage_style = gage_style_config)
   2_process/out/dv_stat_colors.rds:
     command: gd_get('2_process/out/dv_stat_colors.rds.ind')
+
+  # calculate seasonality version
+  2_process/out/dv_seasonality_colors.rds.ind:
+    command: process_seasonality_colors(
+      ind_file = target_name,
+      dv_stats_ind = '2_process/out/dv_stats.rds.ind',
+      color_palette = sites_color_palette,
+      gage_style = gage_style_config)
+  2_process/out/dv_seasonality_colors.rds:
+    command: gd_get('2_process/out/dv_seasonality_colors.rds.ind')
 
   # -- scaling, shifting, rotating config (applies to both states and points) --
   shift_cfg:

--- a/2_process/out/dv_seasonality_colors.rds.ind
+++ b/2_process/out/dv_seasonality_colors.rds.ind
@@ -1,0 +1,3 @@
+warning: dry_put=TRUE; not actually pushed
+hash: 5b5c9991962de69b1faa576e4ead93df
+

--- a/2_process/out/dv_seasonality_colors.rds.ind
+++ b/2_process/out/dv_seasonality_colors.rds.ind
@@ -1,3 +1,2 @@
-warning: dry_put=TRUE; not actually pushed
-hash: 5b5c9991962de69b1faa576e4ead93df
+hash: 99fd3afe78c951985f31e83368e5b245
 

--- a/2_process/src/process_seasonality_colors.R
+++ b/2_process/src/process_seasonality_colors.R
@@ -1,0 +1,47 @@
+#' @title Compute the color for each daily value percentile
+#'
+#' @param ind_file character file name where the output should be saved
+#' @param dv_stats_ind indicator file for the data.frame of dv_data
+#' @param color_palette list of colors to use for the color ramp (from viz_config.yml)
+process_seasonality_colors <- function(ind_file, dv_stats_ind, color_palette, gage_style){
+
+  dv_stats <- readRDS(scipiper::sc_retrieve(dv_stats_ind, remake_file = '2_process.yml'))
+  col_fun <- colorRamp(color_palette$with_percentile)
+
+  dv_stats_scaled <- dv_stats %>%
+    # calculate difference from site_median
+    mutate(delta = dv_val - site_median,
+           per_diff = ifelse(delta == 0, yes = 0,
+                             # if the change is zero, then the percent difference is 0
+                             no = ifelse(site_median == 0,
+                                         # if the site_median is zero, you get Inf
+                                         yes = delta/0.1, # using this as a stand-in for zero for now...
+                                         no = delta/site_median)))
+  per_diff_min <- min(dv_stats_scaled$per_diff, na.rm = T)
+  per_diff_max <- max(dv_stats_scaled$per_diff, na.rm = T)
+
+  dv_stats_scaled2 <- dv_stats_scaled %>%
+    # need to scale to be between 0-1
+    mutate(delta_frac = ifelse(per_diff <= 0,
+                               0.5 * (per_diff - per_diff_min) / (-per_diff_min),
+                               0.5 + 0.5 * per_diff / per_diff_max)) %>%
+    head()
+
+  dv_stats_with_color <- dv_stats_scaled %>%
+    mutate(shape = ifelse(is.na(delta_per),
+                          no = gage_style$with_percentile$pch,
+                          yes = gage_style$no_percentile$pch),
+           size = ifelse(is.na(delta_per),
+                         no = gage_style$with_percentile$cex,
+                         yes = gage_style$no_percentile$cex),
+           color = NA)
+
+  delta_na <- is.na(dv_stats_with_color$delta_per)
+  #this was not working with ifelse inside mutate, still NAs getting into rgb/col_fun
+  dv_stats_with_color$color[!delta_na] <- rgb(col_fun(dv_stats_with_color$delta_per[!delta_na]), maxColorValue = 255)
+  dv_stats_with_color$color[delta_na] <- color_palette$no_percentile
+
+  # Write the data file and the indicator file
+  saveRDS(dv_stats_with_color, scipiper::as_data_file(ind_file))
+  scipiper::gd_put(ind_file)
+}

--- a/2_process/src/process_seasonality_colors.R
+++ b/2_process/src/process_seasonality_colors.R
@@ -9,37 +9,21 @@ process_seasonality_colors <- function(ind_file, dv_stats_ind, color_palette, ga
   col_fun <- colorRamp(color_palette$with_percentile)
 
   dv_stats_scaled <- dv_stats %>%
-    # calculate difference from site_median
-    mutate(delta = dv_val - site_median,
-           per_diff = ifelse(delta == 0, yes = 0,
-                             # if the change is zero, then the percent difference is 0
-                             no = ifelse(site_median == 0,
-                                         # if the site_median is zero, you get Inf
-                                         yes = delta/0.1, # using this as a stand-in for zero for now...
-                                         no = delta/site_median)))
-  per_diff_min <- min(dv_stats_scaled$per_diff, na.rm = T)
-  per_diff_max <- max(dv_stats_scaled$per_diff, na.rm = T)
-
-  dv_stats_scaled2 <- dv_stats_scaled %>%
-    # need to scale to be between 0-1
-    mutate(delta_frac = ifelse(per_diff <= 0,
-                               0.5 * (per_diff - per_diff_min) / (-per_diff_min),
-                               0.5 + 0.5 * per_diff / per_diff_max)) %>%
-    head()
+    group_by(site_no) %>%
+    mutate(p50_quantile = ecdf(p50_va)(p50_va)) %>% # produces values between 0 and 1
+    ungroup()
 
   dv_stats_with_color <- dv_stats_scaled %>%
-    mutate(shape = ifelse(is.na(delta_per),
-                          no = gage_style$with_percentile$pch,
-                          yes = gage_style$no_percentile$pch),
-           size = ifelse(is.na(delta_per),
-                         no = gage_style$with_percentile$cex,
-                         yes = gage_style$no_percentile$cex),
-           color = NA)
-
-  delta_na <- is.na(dv_stats_with_color$delta_per)
-  #this was not working with ifelse inside mutate, still NAs getting into rgb/col_fun
-  dv_stats_with_color$color[!delta_na] <- rgb(col_fun(dv_stats_with_color$delta_per[!delta_na]), maxColorValue = 255)
-  dv_stats_with_color$color[delta_na] <- color_palette$no_percentile
+    mutate(
+      shape = ifelse(is.na(p50_quantile),
+                     no = gage_style$with_percentile$pch,
+                     yes = gage_style$no_percentile$pch),
+      size = ifelse(is.na(p50_quantile),
+                    no = gage_style$with_percentile$cex,
+                    yes = gage_style$no_percentile$cex),
+      color = ifelse(is.na(p50_quantile),
+                     no = rgb(col_fun(p50_quantile), maxColorValue = 255),
+                     yes = color_palette$no_percentile))
 
   # Write the data file and the indicator file
   saveRDS(dv_stats_with_color, scipiper::as_data_file(ind_file))

--- a/6_visualize/src/create_gif_tasks.R
+++ b/6_visualize/src/create_gif_tasks.R
@@ -28,10 +28,10 @@ create_timestep_gif_tasks <- function(timestep_ind, folders){
     },
     command = function(task_name, ...){
       cur_task <- dplyr::filter(rename(tasks, tn=task_name), tn==task_name)
-      sprintf("prep_gage_sites_fun(percentile_color_data_ind = '2_process/out/dv_stat_colors.rds.ind',
+      sprintf("prep_gage_sites_fun(percentile_color_data_ind = '2_process/out/dv_seasonality_colors.rds.ind',
               sites_sp = site_locations_shifted, dateTime=I('%s'))", format(cur_task$timestep, "%Y-%m-%d %H:%M:%S"))
     },
-    depends = "2_process/out/dv_stat_colors.rds"
+    depends = "2_process/out/dv_seasonality_colors.rds"
   )
 
   callouts <- scipiper::create_task_step(

--- a/6_visualize/src/create_gif_tasks.R
+++ b/6_visualize/src/create_gif_tasks.R
@@ -28,10 +28,12 @@ create_timestep_gif_tasks <- function(timestep_ind, folders){
     },
     command = function(task_name, ...){
       cur_task <- dplyr::filter(rename(tasks, tn=task_name), tn==task_name)
-      sprintf("prep_gage_sites_fun(percentile_color_data_ind = '2_process/out/dv_seasonality_colors.rds.ind',
-              sites_sp = site_locations_shifted, dateTime=I('%s'))", format(cur_task$timestep, "%Y-%m-%d %H:%M:%S"))
-    },
-    depends = "2_process/out/dv_seasonality_colors.rds"
+      psprintf(
+        "prep_gage_sites_fun(",
+        "percentile_color_data_ind = '2_process/out/dv_seasonality_colors.rds.ind',",
+        "sites_sp = site_locations_shifted,",
+        "dateTime=I('%s'))"=format(cur_task$timestep, "%Y-%m-%d %H:%M:%S"))
+    }
   )
 
   callouts <- scipiper::create_task_step(

--- a/build/status/Ml9wcm9jZXNzL291dC9kdl9zZWFzb25hbGl0eV9jb2xvcnMucmRzLmluZA.yml
+++ b/build/status/Ml9wcm9jZXNzL291dC9kdl9zZWFzb25hbGl0eV9jb2xvcnMucmRzLmluZA.yml
@@ -1,0 +1,14 @@
+version: 0.3.0
+name: 2_process/out/dv_seasonality_colors.rds.ind
+type: file
+hash: 49fa9298f79f520463bd357f6f8cfcf8
+time: 2018-11-15 20:22:38 UTC
+depends:
+  2_process/out/dv_stats.rds.ind: 0dc9a48f439dabe61356bbab03211a3f
+  sites_color_palette: f4bda45333f2e464042d4b4851a2ec49
+  gage_style_config: e3491cdd3ecb0a0a35adcba91aa1096e
+fixed: 484099f00715bd33585e3194548bcc96
+code:
+  functions:
+    process_seasonality_colors: 24ec1c29cda964d5fc5ef7e3bf933be1
+

--- a/build/status/Ml9wcm9jZXNzL291dC9kdl9zZWFzb25hbGl0eV9jb2xvcnMucmRzLmluZA.yml
+++ b/build/status/Ml9wcm9jZXNzL291dC9kdl9zZWFzb25hbGl0eV9jb2xvcnMucmRzLmluZA.yml
@@ -1,8 +1,8 @@
 version: 0.3.0
 name: 2_process/out/dv_seasonality_colors.rds.ind
 type: file
-hash: 49fa9298f79f520463bd357f6f8cfcf8
-time: 2018-11-15 20:22:38 UTC
+hash: 32d95ce77342917db5dfc34176161d0a
+time: 2018-11-16 22:13:11 UTC
 depends:
   2_process/out/dv_stats.rds.ind: 0dc9a48f439dabe61356bbab03211a3f
   sites_color_palette: f4bda45333f2e464042d4b4851a2ec49
@@ -10,5 +10,5 @@ depends:
 fixed: 484099f00715bd33585e3194548bcc96
 code:
   functions:
-    process_seasonality_colors: 24ec1c29cda964d5fc5ef7e3bf933be1
+    process_seasonality_colors: 3d8cdfbdcc8eb477493443aca2a085b8
 


### PR DESCRIPTION
@lindsaycarr did a lot of the work on this, then I copied her branch and modified. Now this animation shows (I think!) the day-of-year medians at each site, scaled to percentiles of those values within each site. So it's not FY18 specific, it's more about educating about seasonality generally. This is one of the two next-step options outlined at https://github.com/USGS-VIZLAB/gage-conditions-gif/issues/66#issuecomment-439534146

Movie is shared in slack.