### PR TITLE
single size for dots

### DIFF
--- a/2_process/src/process_dv_stat_styles.R
+++ b/2_process/src/process_dv_stat_styles.R
@@ -19,10 +19,10 @@ process_dv_stat_styles <- function(ind_file, dv_stats_ind, color_palette, size_p
   col_fun <- colorRamp(color_palette$with_percentile)
   size_fun <- function(percentile) {
     # to use constant dot size:
-    #gage_style$no_percentile$cex
+    gage_style$with_percentile$cex
 
     # to show seasonality through dot size:
-    size_palette$cex_range[1] + percentile*(diff(size_palette$cex_range))
+    #size_palette$cex_range[1] + percentile*(diff(size_palette$cex_range))
   }
 
   # apply the styling functions to add style columns to the data.frame

--- a/viz_config.yml
+++ b/viz_config.yml
@@ -32,7 +32,7 @@ basemap:
 sites_color_palette:
   with_percentile: ['#ca0020','#f4a582','#efefef','#efefef','#92c5de','#034064']
   no_percentile: "gray50"
-sites_size_palette:
+sites_size_palette: # not actually using this right now (see 2_process/src/process_dv_stat_styles.R, line 22)
   cex_range: [0.5, 2.5] # both must be formatted as doubles (no integers)
 gage_style:
   with_percentile:


### PR DESCRIPTION
Following #84, we are going back to just one size for the dots but leaving in the code that easily allows us to change our mind.