### PR TITLE
Framerate & tiny text changes

### DIFF
--- a/6_visualize/src/combine_animation_frames.R
+++ b/6_visualize/src/combine_animation_frames.R
@@ -8,7 +8,7 @@ combine_animation_frames <- function(gif_file, animation_cfg) {
                          newName = file.path("6_visualize/tmp", paste0("frame_", countFormatted, ".png")))
   file.rename(from = file_name_df$origName, to = file_name_df$newName)
   shell_command <- sprintf(
-    "ffmpeg -y -framerate %s -i 6_visualize/tmp/frame_%%03d.png -framerate %s -pix_fmt yuv420p %s",
+    "ffmpeg -y -framerate %s -i 6_visualize/tmp/frame_%%03d.png -r %s -pix_fmt yuv420p %s",
     animation_cfg$frame_rate, animation_cfg$output_frame_rate, gif_file)
   system(shell_command)
   file.rename(from = file_name_df$newName, to = file_name_df$origName)

--- a/viz_config.yml
+++ b/viz_config.yml
@@ -98,7 +98,7 @@ datewheel_cfg:
 # gif options
 animation:
   frame_rate: 5 #original input frames per second
-  output_frame_rate: 5 #fps, but the actual frames in the video (not 1:1 with input)
+  output_frame_rate: 10 #fps, but the actual frames in the video (not 1:1 with input)
 
 # Image placement for function calls of USGS watermark, legend, datetime, etc..
 #  These are fraction of the coordinate space, where 0,0 is bottom left of figure (some stuff is right justified though - legend)

--- a/viz_config.yml
+++ b/viz_config.yml
@@ -137,7 +137,7 @@ callouts:
       start: "2017-12-08"
       end: "2017-12-22"
     text:
-      label: ["Much-below-average", "December precipitation", "along the West Coast"]
+      label: ["Low December precipitation", "along the West Coast"]
       x_loc: 0.32 #this is in percentage space, relative to the plotting device
       y_loc: 0.7
       pos: 4
@@ -151,7 +151,7 @@ callouts:
       start: "2018-02-15"
       end: "2018-02-28"
     text:
-      label: ["Drought begins to", "develop in UT, CO,", "NM, AZ, north TX,", "OK, and KS"]
+      label: ["Drought begins to", "develop in UT, CO,", "NM, AZ, and KS"]
       x_loc: 0.58
       y_loc: 0.6
       pos: 3
@@ -179,7 +179,7 @@ callouts:
       start: "2018-09-08"
       end: "2018-09-21"
     text:
-      label: ["Hurricane Florence", "parks over NC and SC"]
+      label: ["Hurricane Florence", "hovers over NC and SC"]
       x_loc: 0.82
       y_loc: 0.36
       pos: 1


### PR DESCRIPTION
Fixes #108 & #109. 

For some reason, frames would be skipped occasionally. I Googled a lot about ffmpeg and I still don't quite understand, but the changes I made here help keep the framerate still fairly slow but doesn't skip frames. [This Stackoverflow comment](https://unix.stackexchange.com/questions/68770/converting-png-frames-to-video-at-1-fps) kind of helped with that. 