### PR TITLE
Last tweaks to get Elmera's build working

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,10 @@ While not always necessary, you may find that you want to increase the text size
 
 #### Rebuild the animation
 
-Now that the specifications for frames are updated and ready for the Instagram version, you need to rebuild all of the frames. Use the code below. No need to rename this one from `year_in_review.mp4` to something else since we will process it further in the next step.
+Now that the specifications for frames are updated and ready for the Instagram version, you need to rebuild all of the frames. Follow these steps:
+
+1. We need to start with a blank `tmp/` folder. Instead of clearing the contents in the existing folder, rename it from `tmp/` to `tmp_twitter/`. I like to retain all of the Twitter-sized frames for easy access should we need rebuild the videos again. When you build the Instagram ones in the next step, they will automatically get added into a new `tmp/` folder.
+2. Use the code below to build the Instagram-sized frames and create the new video. No need to rename the video created here from `year_in_review.mp4` to something else since we will process it further in the next step (and that code expects it to be named `year_in_review.mp4`).
 
 ```r
 source("helper_fxns_pipeline.R")

--- a/helper_fxns_outreach_media.R
+++ b/helper_fxns_outreach_media.R
@@ -260,7 +260,7 @@ generate_insta_video <- function(version_info) {
 
   # Title bleeds into map a bit, so need to cover title part with drawbox
   system(sprintf(
-    'ffmpeg -y -i %s -vf "drawbox=x=0:y=0:w=%s:h=%s:t=max:color=white" %s',
+    'ffmpeg -y -i %s -vf "drawbox=x=0:y=0:w=%s:h=%s:t=fill:color=white" %s',
     video_file,
     title_guess_width,
     title_guess_height,

--- a/helper_fxns_outreach_media.R
+++ b/helper_fxns_outreach_media.R
@@ -337,7 +337,7 @@ generate_insta_video <- function(version_info) {
     "(W*0.05)",# Left
     sprintf("%s + (H-%s)*2/3 - (h/2)", map_guess_height, map_guess_height), # Center in white space below map & below title
     # Add footnote
-    sprintf("(W/2)-(w/2)", footnote_guess_width), # Center
+    "(W/2)-(w/2)", # Center
     sprintf("(H-%s)", footnote_guess_height*1.1), # Just up from bottom
     insta_dim,
     sprintf("%02d", reg_animation_start), # start animation

--- a/helper_fxns_pipeline.R
+++ b/helper_fxns_pipeline.R
@@ -38,28 +38,50 @@ rebuild_frame_sections <- function(intro = FALSE, timestep = FALSE, pause = FALS
   if(intro) {
     # Build the intro frames
     scipiper::scmake('6_intro_gif_tasks.yml', remake_file = '6_visualize.yml', force = TRUE)
-    tryCatch(scipiper::scmake('6_visualize/log/6_intro_gif_tasks.ind', remake_file = '6_visualize.yml', force=TRUE),
-             error = function(e) warning('Skipping the error that pops up about no file being created for intro'))
+    catch_known_build_error(scipiper::scmake('6_visualize/log/6_intro_gif_tasks.ind', remake_file = '6_visualize.yml', force=TRUE))
   }
 
   if(timestep) {
     # Build the timestep frames
     scipiper::scmake('6_timestep_gif_tasks.yml', remake_file = '6_visualize.yml', force = TRUE)
-    scipiper::scmake('6_visualize/log/6_timestep_gif_tasks.ind', remake_file = '6_visualize.yml', force=TRUE)
+    catch_known_build_error(scipiper::scmake('6_visualize/log/6_timestep_gif_tasks.ind', remake_file = '6_visualize.yml', force=TRUE))
   }
 
   if(pause) {
     # Build the pause frames
     scipiper::scmake('6_pause_gif_tasks.yml', remake_file = '6_visualize.yml', force=TRUE)
-    scipiper::scmake('6_visualize/log/6_pause_gif_tasks.ind', remake_file = '6_visualize.yml', force=TRUE)
+    catch_known_build_error(scipiper::scmake('6_visualize/log/6_pause_gif_tasks.ind', remake_file = '6_visualize.yml', force=TRUE))
   }
 
   if(final) {
     # Build the final frames
     scipiper::scmake('6_final_gif_tasks.yml', remake_file = '6_visualize.yml', force = TRUE)
-    scipiper::scmake('6_visualize/log/6_final_gif_tasks.ind', remake_file = '6_visualize.yml', force=TRUE)
+    catch_known_build_error(scipiper::scmake('6_visualize/log/6_final_gif_tasks.ind', remake_file = '6_visualize.yml', force=TRUE))
   }
 
+}
+
+#' Function to catch the error about a file not being created
+#'
+#' @description This can be used to wrap any `scmake()` call
+#' so that it prevents an error related to no file being created
+#' from stopping the code. Not ideal, but since we are using
+#' `force = TRUE` for almost every single `scmake()` call, I know
+#' that things will be rebuilding and this error is a bit of a mystery.
+#'
+#' @param expr the expression to catch the error
+#'
+catch_known_build_error <- function(expr) {
+  tryCatch(expr, error = function(e) {
+    if(grepl('did not create file', e)) {
+      # If it's the error we already know about where the `.ind` file isn't created,
+      # skip the error and print a warning instead so that the code can continue.
+      warning('Skipping the error that pops up about no file being created for intro')
+    } else {
+      # If it is not the error we already know about, actually throw an error!
+      stop(e)
+    }
+  })
 }
 
 #' Function to rebuild the video


### PR DESCRIPTION
Worked through these with @elmeraa on a call earlier.

1. One more instance of the `fill` arg replacing `max` in newer ffmpeg versions
2. Deleting an unused `sprintf()` so that a warning will stop showing up
3. Add documentation about the need to clear `tmp` before rebuilding the Instagram frames (due to [this line](https://github.com/USGS-VIZLAB/gage-conditions-gif/blob/main/6_visualize/src/combine_animation_frames.R#L5) which is pulling in bad frames and causing build errors if `tmp` isn't cleared first)
4. Added a helper function to `tryCatch` a known scmake error for building the `.ind` files.